### PR TITLE
Add expand_keys_diff property and behavior.

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ If you would like git2consul to shutdown every time its configuration changes, y
 
 ##### expand_keys
 
+There are a couple of general behaviors in regards to `expand_keys`:
+
+* By default, the entire existing tree of keys represented by the file will be deleted and then rebuilt on any change to the file.
+
+* Setting `"expand_keys_diff": true` will apply a diff between the contents of the file and the existing keys and only add/update/delete the necessary keys.
+
 ###### JSON
 
 If you would like git2consul to treat JSON documents in your repo as fully formed subtrees, you can enable expand_keys mode via inclusion of the field `"expand_keys": true` at the top level of the repo's configuration.  If this mode is enabled, git2consul will treat any valid JSON file (that is, any file with extension ".json" that parses to an object) as if it contains a subtree of Consul KVs.  For example, if you have the file `root.json` in repo `expando_keys` with the following contents:

--- a/lib/consul/index.js
+++ b/lib/consul/index.js
@@ -31,6 +31,16 @@ var write_content_to_consul = function(key_name, content, cb) {
   });
 };
 
+var delete_from_consul = function(key_name, cb) {
+  logger.trace('Deleting key %s', key_name);
+  consul.kv.del({'key': key_name, token: token}, function(err) {
+    if (err) {
+      return cb('Failed to delete key ' + key_name + ' due to ' + err);
+    }
+    cb();
+  });
+};
+
 /**
  * Given a branch and a file, determine the resource's name in the consul KV store
  */
@@ -72,27 +82,77 @@ var render_obj = function(parts, prefix, obj) {
 
     if (_.isObject(val)) return render_obj(parts, prefix + '/' + encodeURIComponent(key), val)
 
-    parts.push({'key': prefix + '/' + encodeURIComponent(key), 'value': val});
+    // Value of all KV objects should be treated as strings
+    parts.push({'key': prefix + '/' + encodeURIComponent(key), 'value': val.toString()});
   });
 }
 
 /**
- * Walk through obj, creating a Consul write operation for each kv pair.  Objects are treated
- * as parents of subtrees.  Arrays are ignored since they add annoying problems (multiple array
- * entries can have the same value, so what do we do then?).
+ * After computing the diff between the object and the existing KV records,
+ * perform the necessary consul operations such that the state in consul matches
+ * the diff.
  */
-var populate_kvs_from_object = function(branch, prefix, obj, cb) {
+var populate_kvs_from_object = function(branch, prefix, obj, existing_kvs, cb) {
+  var write_kvs = [];
+  var delete_kvs = [];
+  var candidate_kvs = [];
 
-  var writes = [];
+  render_obj(candidate_kvs, prefix, obj);
 
-  render_obj(writes, prefix, obj);
+  // This avoids unnecessary copying if there are no existing KV records.
+  if (existing_kvs.length > 0) {
+    diff_kvs(write_kvs, delete_kvs, candidate_kvs, existing_kvs);
+  } else {
+    write_kvs = candidate_kvs;
+  }
 
-  logger.debug('Expandable file %s yielded %s keys', prefix, writes.length);
+  logger.debug('Expandable file %s yielded %s keys (%s writes, %s deletes)',
+               prefix,
+               candidate_kvs.length,
+               write_kvs.length,
+               delete_kvs.length);
 
-  cb = _.after(writes.length, cb);
+  // This helps ensure that writes happen after all deletes
+  // have been processed.
+  var do_writes = _.after(delete_kvs.length, function(err) {
+    if (err) return cb(err);
 
-  writes.forEach(function(write) {
-    write_content_to_consul(write.key, write.value, cb);
+    if (write_kvs.length > 0) {
+      cb = _.after(write_kvs.length, cb);
+      write_kvs.forEach(function(write) {
+        write_content_to_consul(write.key, write.value, cb);
+      });
+    } else {
+      cb();
+    }
+  });
+
+  if (delete_kvs.length > 0) {
+    delete_kvs.forEach(function(del) {
+      delete_from_consul(del.key, do_writes);
+    });
+  } else {
+    do_writes();
+  }
+};
+
+/**
+ * Compare the list of candidate KV records to the list of existing KV records.
+ * Based on the comparison, populate the provided lists for write and delete
+ * operations against the KV store.
+ */
+var diff_kvs = function(write_kvs, delete_kvs, candidate_kvs, existing_kvs) {
+  // If the candidate kv is not already in the list of existing kvs set to the
+  // same value, then we know we need to write the kv.
+  candidate_kvs.forEach(function(kv) {
+    if (!_.findWhere(existing_kvs, kv)) {
+      write_kvs.push(kv);
+    }
+  });
+  // If the existing kv is not in the list of candidate kvs, regardless of value,
+  // then we know we need to delete the kv.
+  existing_kvs.forEach(function(kv) {
+    if (!_.findWhere(candidate_kvs, {'key': kv.key})) delete_kvs.push(kv);
   });
 };
 
@@ -101,14 +161,14 @@ var populate_kvs_from_object = function(branch, prefix, obj, cb) {
  */
 var file_modified = function(branch, file, cb) {
 
-  var handle_json_kv_file = function(file_path, cb) {
+  var handle_json_kv_file = function(file_path, kvs, cb) {
       fs.readFile(file_path, {encoding: 'utf8'}, function (err, body) {
         /* istanbul ignore if */
         if (err) return cb('Failed to read key ' + file_path + ' due to ' + err);
         body = body ? body.trim() : '';
         try {
           var obj = JSON.parse(body);
-          populate_kvs_from_object(branch, create_key_name(branch, file), obj, cb);
+          populate_kvs_from_object(branch, create_key_name(branch, file), obj, kvs, cb);
         } catch (e) {
           logger.warn("Failed to parse .json file.  Using body string as a KV.");
           write_content_to_consul(create_key_name(branch, file), body, cb);
@@ -116,14 +176,14 @@ var file_modified = function(branch, file, cb) {
       });
   };
 
-  var handle_properties_kv_file = function(file_path, common_properties_relative_path, cb) {
+  var handle_properties_kv_file = function(file_path, common_properties_relative_path, kvs, cb) {
     function extract_and_populate_properties(file_body, common_body, cb) {
       utils.load_properties(file_body, common_body, function (error, obj) {
         if (error) {
           logger.warn('Failed to load properties for : ' + file + ' due to : ' + error + '.' + ' Using body string as a KV.');
           handle_as_flat_file(file_path, branch, file, cb);
         } else {
-          populate_kvs_from_object(branch, create_key_name(branch, file), obj, cb);
+          populate_kvs_from_object(branch, create_key_name(branch, file), obj, kvs, cb);
         }
       });
     }
@@ -148,14 +208,14 @@ var file_modified = function(branch, file, cb) {
     });
   };
 
-  var handle_yaml_kv_file = function(file_path, cb) {
+  var handle_yaml_kv_file = function(file_path, kvs, cb) {
     fs.readFile(file_path, {encoding: 'utf8'}, function (err, body) {
       /* istanbul ignore if */
       if (err) return cb('Failed to read key ' + file_path + ' due to ' + err);
       body = body ? body.trim() : '';
       try {
         var obj = yaml.safeLoad(body);
-        populate_kvs_from_object(branch, create_key_name(branch, file), obj, cb);
+        populate_kvs_from_object(branch, create_key_name(branch, file), obj, kvs, cb);
       } catch (e) {
         logger.warn("Failed to parse .yaml file " + file + ".  Using body string as a KV.");
         write_content_to_consul(create_key_name(branch, file), body, cb);
@@ -172,24 +232,13 @@ var file_modified = function(branch, file, cb) {
     });
   };
 
-  var handle_expanded_keys_with_different_file_types = function() {
+  var handle_expanded_keys_with_different_file_types = function(kvs) {
     if (file.endsWith('.json')) {
-      // Delete current tree.  Yeah, I know this is kinda the coward's way out, but it's a hell of a lot
-      // easier to get provably correct than diffing the file against the contents of the KV store.
-      file_deleted(branch, file, function (err) {
-        if (err) return cb('Failed to delete key ' + key_name + ' due to ' + err);
-        handle_json_kv_file(fqf, cb);
-      });
+      handle_json_kv_file(fqf, kvs, cb);
     } else if (file.endsWith('.yaml') || file.endsWith('.yml')) {
-      file_deleted(branch, file, function (err) {
-        if (err) return cb('Failed to delete key ' + key_name + ' due to ' + err);
-        handle_yaml_kv_file(fqf, cb);
-      });
+      handle_yaml_kv_file(fqf, kvs, cb);
     } else if (file.endsWith('.properties')) {
-      file_deleted(branch, file, function (err) {
-        if (err) return cb('Failed to delete key ' + key_name + ' due to ' + err);
-        handle_properties_kv_file(fqf, branch.common_properties, cb);
-      });
+      handle_properties_kv_file(fqf, branch.common_properties, kvs, cb);
     } else {
       handle_as_flat_file(fqf, branch, file, cb);
     }
@@ -198,8 +247,18 @@ var file_modified = function(branch, file, cb) {
   var fqf = branch.branch_directory + path.sep + file;
   logger.trace('Attempting to read "%s"', fqf);
 
-  if (branch.expand_keys) {
-    handle_expanded_keys_with_different_file_types();
+  if (branch.expand_keys && branch.expand_keys_diff) {
+    get_kvs(branch, file, function(err, kvs) {
+      if (err) return cb('Failed to load KV tree ' + create_key_name(branch, file) + ' due to ' + err);
+      handle_expanded_keys_with_different_file_types(kvs);
+    });
+  } else if (branch.expand_keys) {
+    // Delete current tree.  Yeah, I know this is kinda the coward's way out, but it's a hell of a lot
+    // easier to get provably correct than diffing the file against the contents of the KV store.
+    file_deleted(branch, file, function (err) {
+      if (err) return cb('Failed to delete key ' + create_key_name(branch, file) + ' due to ' + err);
+      handle_expanded_keys_with_different_file_types([]);
+    });
   } else {
     handle_as_flat_file(fqf, branch, file, cb);
   }
@@ -219,6 +278,34 @@ var file_deleted = function(branch, file, cb) {
     /* istanbul ignore if */
     if (err) return cb('Failed to delete key ' + key_name + ' due to ' + err);
     cb();
+  });
+};
+
+/**
+ * Get all KV records under the prefix, and transform them into an array
+ * of objects like:
+ * [{'key': k, 'value': v}]
+ */
+var get_kvs = function(branch, file, cb) {
+  // Prepend branch name to the KV so that the subtree is properly namespaced in Consuls
+  var key_name = create_key_name(branch, file);
+
+  logger.trace('Getting tree for key %s', key_name);
+
+  // Load all sub-keys as a flattened tree of KV pairs
+  consul.kv.get({'key': key_name, token: token, recurse: true}, function(err, kvs, res) {
+    if (err) return cb('Failed to get tree for key ' + key_name + ' due to ' + err, undefined);
+
+    var tree = []
+    if (kvs) {
+      kvs.forEach(function(kv) {
+        if (kv.Value === null) kv.Value = '';
+        logger.trace('Got key %s with value:\n%s', kv.Key, kv.Value);
+        tree.push({'key': kv.Key, 'value': kv.Value});
+      });
+    }
+
+    cb(undefined, tree);
   });
 };
 

--- a/lib/git/branch.js
+++ b/lib/git/branch.js
@@ -16,6 +16,7 @@ function Branch(repo_config, name) {
   Object.defineProperty(this, 'branch_parent', {value: repo_config.local_store + path.sep + repo_config.name});
   Object.defineProperty(this, 'branch_directory', {value: this.branch_parent + path.sep + name});
   Object.defineProperty(this, 'expand_keys', { value: repo_config['expand_keys'] === true });
+  Object.defineProperty(this, 'expand_keys_diff', { value: repo_config['expand_keys_diff'] === true });
   Object.defineProperty(this, 'common_properties', { value: repo_config['common_properties']});
   Object.defineProperty(this, 'include_branch_name', {
     // If include_branch_name is not set, assume true.  Otherwise, identity check the value against true.

--- a/test/utils/consul_utils.js
+++ b/test/utils/consul_utils.js
@@ -19,6 +19,17 @@ exports.setValue = function(key, value, cb) {
   });
 };
 
+exports.getKeyIndices = function(key, cb) {
+  consul.kv.get({'key': key}, function(err, value) {
+    if (err) return cb(err);
+
+    cb(null,
+       value === undefined ? value : value.CreateIndex,
+       value === undefined ? value : value.ModifyIndex,
+       value === undefined ? value : value.LockIndex);
+  });
+};
+
 exports.validateValue = function(key, expected_value, cb) {
   logger.trace('Looking for key %s with value %s', key, expected_value);
   exports.getValue(key, function(err, value) {
@@ -28,6 +39,20 @@ exports.validateValue = function(key, expected_value, cb) {
     } else {
       (value != undefined).should.equal(true);
       value.should.equal(expected_value);
+    }
+    cb();
+  })
+};
+
+exports.validateModifyIndex = function(key, expected_value, cb) {
+  logger.trace('Looking for key %s with ModifyIndex %s', key, expected_value);
+  exports.getKeyIndices(key, function(err, createIndex, modifyIndex, lockIndex) {
+    if (err) return cb(err);
+    if (!expected_value) {
+      (modifyIndex == undefined).should.equal(true);
+    } else {
+      (modifyIndex != undefined).should.equal(true);
+      modifyIndex.should.equal(expected_value);
     }
     cb();
   })


### PR DESCRIPTION
The expand_keys behavior is cool, but it currently deletes the entire
tree represented by a file and recreates it for any change made in a
file. This is not desireable for any large number of keys for two
reasons:
1. When only a subset of the tree changes, we result in a large number
   of writes.
2. Watches will fire when keys that have not really changes are
   modified.

This commit adds a setting called "expand_keys_diff" that can be set at
the repo level. When set to true, then a diff is performed between the
resulting tree of the file and the existing tree in consul. Only the
necessary add/update/delete operations are performed, and thus both
concerns above are eliminated.

The question of consistency is a red herring as in general practice the
replication lag between consul instances it negligible, and good
practice would dictate that no other client be modifying the keys
mirrored by git2consul.
